### PR TITLE
add --version option

### DIFF
--- a/kasane/cmd.py
+++ b/kasane/cmd.py
@@ -1,11 +1,11 @@
 # Copyright 2018 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,11 +21,13 @@ import click
 
 from kasane import ops
 
+
 @click.group()
 @click.option('-p', '--path')
 @click.option('-l', '--lib')
 @click.option('-c', '--config')
 @click.option('-e', '--env', multiple=True)
+@click.version_option(message=('%(prog)s v%(version)s'))
 @click.pass_context
 def cli(ctx, path: str, lib: str, config: str, env: List[str]):
   if not ctx.obj:
@@ -45,6 +47,7 @@ def cli(ctx, path: str, lib: str, config: str, env: List[str]):
   ctx.obj['j'] = ops.Jsonnet([path] + [lib], collectedenv)
   ctx.obj['rc'] = ops.RuntimeConfig(check_hashes=True, jsonnet=ctx.obj['j'], kubeconfig=ctx.obj['config'])
 
+
 @cli.add_command
 @click.command()
 @click.pass_context
@@ -57,12 +60,13 @@ def show(ctx, raw: bool, validate_signatures: bool, k: str, ignore_env: bool) ->
 
   if ignore_env:
     ctx.obj['j'].ignore_env = True
-  
+
   ctx.obj['rc'] = ops.common.RuntimeConfig(
     check_hashes=validate_signatures,
     jsonnet=ctx.obj['rc'].jsonnet,
     kubeconfig=ctx.obj['rc'].kubeconfig)
   ops.show(ctx.obj['path'], ctx.obj['rc'], not raw, k)
+
 
 @cli.add_command
 @click.command()
@@ -77,6 +81,7 @@ def apply(ctx) -> None:
     print('known env:', ', '.join(ctx.obj['env'].keys()))
     exit(1)
 
+
 @cli.add_command
 @click.command()
 @click.option('--lock-all/--lock-remote-only', default=False)
@@ -85,6 +90,7 @@ def update(ctx, lock_all: bool) -> None:
   '''updates the bundle'''
   
   ops.update(ctx.obj['path'], ctx.obj['rc'], lock_all)
+
 
 def main():
   cli()


### PR DESCRIPTION
@farcaller `click` actually has a pre-defined decorator for implementing a `--version` option, the `click.version_option()` and by default, it falls back to auto-fetching the version from setuptools. Also, I've formatted the message string to take the form `kasane v0.1.3`, let me know if some other format is more desirable.

P.S made some small additions as per PEP8 given that it's not going to harm the commit history and mess up git blame usage for others.

Reference:
- https://click.palletsprojects.com/en/7.x/api/#click.version_option

Closes #14 
